### PR TITLE
Add curl-7/8 + openssl 1.1.1/3 build variants

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,44 +8,64 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_libdeflate1.12openssl1.1.1:
-        CONFIG: linux_64_libdeflate1.12openssl1.1.1
+      linux_64_libcurl7libdeflate1.12openssl1.1.1:
+        CONFIG: linux_64_libcurl7libdeflate1.12openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.12openssl3:
-        CONFIG: linux_64_libdeflate1.12openssl3
+      linux_64_libcurl7libdeflate1.12openssl3:
+        CONFIG: linux_64_libcurl7libdeflate1.12openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.13openssl1.1.1:
-        CONFIG: linux_64_libdeflate1.13openssl1.1.1
+      linux_64_libcurl7libdeflate1.13openssl1.1.1:
+        CONFIG: linux_64_libcurl7libdeflate1.13openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.13openssl3:
-        CONFIG: linux_64_libdeflate1.13openssl3
+      linux_64_libcurl7libdeflate1.13openssl3:
+        CONFIG: linux_64_libcurl7libdeflate1.13openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.14openssl1.1.1:
-        CONFIG: linux_64_libdeflate1.14openssl1.1.1
+      linux_64_libcurl7libdeflate1.14openssl1.1.1:
+        CONFIG: linux_64_libcurl7libdeflate1.14openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.14openssl3:
-        CONFIG: linux_64_libdeflate1.14openssl3
+      linux_64_libcurl7libdeflate1.14openssl3:
+        CONFIG: linux_64_libcurl7libdeflate1.14openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.16openssl1.1.1:
-        CONFIG: linux_64_libdeflate1.16openssl1.1.1
+      linux_64_libcurl7libdeflate1.16openssl1.1.1:
+        CONFIG: linux_64_libcurl7libdeflate1.16openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.16openssl3:
-        CONFIG: linux_64_libdeflate1.16openssl3
+      linux_64_libcurl7libdeflate1.16openssl3:
+        CONFIG: linux_64_libcurl7libdeflate1.16openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.17openssl1.1.1:
-        CONFIG: linux_64_libdeflate1.17openssl1.1.1
+      linux_64_libcurl7libdeflate1.17openssl1.1.1:
+        CONFIG: linux_64_libcurl7libdeflate1.17openssl1.1.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libdeflate1.17openssl3:
-        CONFIG: linux_64_libdeflate1.17openssl3
+      linux_64_libcurl7libdeflate1.17openssl3:
+        CONFIG: linux_64_libcurl7libdeflate1.17openssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_libcurl8libdeflate1.12openssl3:
+        CONFIG: linux_64_libcurl8libdeflate1.12openssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_libcurl8libdeflate1.13openssl3:
+        CONFIG: linux_64_libcurl8libdeflate1.13openssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_libcurl8libdeflate1.14openssl3:
+        CONFIG: linux_64_libcurl8libdeflate1.14openssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_libcurl8libdeflate1.16openssl3:
+        CONFIG: linux_64_libcurl8libdeflate1.16openssl3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_libcurl8libdeflate1.17openssl3:
+        CONFIG: linux_64_libcurl8libdeflate1.17openssl3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,35 +8,65 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_libdeflate1.12:
-        CONFIG: osx_64_libdeflate1.12
+      osx_64_libcurl7libdeflate1.12:
+        CONFIG: osx_64_libcurl7libdeflate1.12
         UPLOAD_PACKAGES: 'True'
-      osx_64_libdeflate1.13:
-        CONFIG: osx_64_libdeflate1.13
+      osx_64_libcurl7libdeflate1.13:
+        CONFIG: osx_64_libcurl7libdeflate1.13
         UPLOAD_PACKAGES: 'True'
-      osx_64_libdeflate1.14:
-        CONFIG: osx_64_libdeflate1.14
+      osx_64_libcurl7libdeflate1.14:
+        CONFIG: osx_64_libcurl7libdeflate1.14
         UPLOAD_PACKAGES: 'True'
-      osx_64_libdeflate1.16:
-        CONFIG: osx_64_libdeflate1.16
+      osx_64_libcurl7libdeflate1.16:
+        CONFIG: osx_64_libcurl7libdeflate1.16
         UPLOAD_PACKAGES: 'True'
-      osx_64_libdeflate1.17:
-        CONFIG: osx_64_libdeflate1.17
+      osx_64_libcurl7libdeflate1.17:
+        CONFIG: osx_64_libcurl7libdeflate1.17
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_libdeflate1.12:
-        CONFIG: osx_arm64_libdeflate1.12
+      osx_64_libcurl8libdeflate1.12:
+        CONFIG: osx_64_libcurl8libdeflate1.12
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_libdeflate1.13:
-        CONFIG: osx_arm64_libdeflate1.13
+      osx_64_libcurl8libdeflate1.13:
+        CONFIG: osx_64_libcurl8libdeflate1.13
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_libdeflate1.14:
-        CONFIG: osx_arm64_libdeflate1.14
+      osx_64_libcurl8libdeflate1.14:
+        CONFIG: osx_64_libcurl8libdeflate1.14
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_libdeflate1.16:
-        CONFIG: osx_arm64_libdeflate1.16
+      osx_64_libcurl8libdeflate1.16:
+        CONFIG: osx_64_libcurl8libdeflate1.16
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_libdeflate1.17:
-        CONFIG: osx_arm64_libdeflate1.17
+      osx_64_libcurl8libdeflate1.17:
+        CONFIG: osx_64_libcurl8libdeflate1.17
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl7libdeflate1.12:
+        CONFIG: osx_arm64_libcurl7libdeflate1.12
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl7libdeflate1.13:
+        CONFIG: osx_arm64_libcurl7libdeflate1.13
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl7libdeflate1.14:
+        CONFIG: osx_arm64_libcurl7libdeflate1.14
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl7libdeflate1.16:
+        CONFIG: osx_arm64_libcurl7libdeflate1.16
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl7libdeflate1.17:
+        CONFIG: osx_arm64_libcurl7libdeflate1.17
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl8libdeflate1.12:
+        CONFIG: osx_arm64_libcurl8libdeflate1.12
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl8libdeflate1.13:
+        CONFIG: osx_arm64_libcurl8libdeflate1.13
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl8libdeflate1.14:
+        CONFIG: osx_arm64_libcurl8libdeflate1.14
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl8libdeflate1.16:
+        CONFIG: osx_arm64_libcurl8libdeflate1.16
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_libcurl8libdeflate1.17:
+        CONFIG: osx_arm64_libcurl8libdeflate1.17
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_libcurl7libdeflate1.12openssl1.1.1.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.12openssl1.1.1.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,12 +15,15 @@ docker_image:
 libcurl:
 - '7'
 libdeflate:
-- '1.14'
+- '1.12'
 openssl:
-- '3'
+- 1.1.1
 target_platform:
 - linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.12openssl3.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.12openssl3.yaml
@@ -1,24 +1,29 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '14'
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
 - '7'
 libdeflate:
-- '1.17'
-macos_machine:
-- arm64-apple-darwin20.0.0
+- '1.12'
+openssl:
+- '3'
 target_platform:
-- osx-arm64
+- linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.13openssl1.1.1.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.13openssl1.1.1.yaml
@@ -1,0 +1,29 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libcurl:
+- '7'
+libdeflate:
+- '1.13'
+openssl:
+- 1.1.1
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.13openssl3.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.13openssl3.yaml
@@ -1,0 +1,29 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libcurl:
+- '7'
+libdeflate:
+- '1.13'
+openssl:
+- '3'
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.14openssl1.1.1.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.14openssl1.1.1.yaml
@@ -1,0 +1,29 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libcurl:
+- '7'
+libdeflate:
+- '1.14'
+openssl:
+- 1.1.1
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.14openssl3.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.14openssl3.yaml
@@ -1,0 +1,29 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libcurl:
+- '7'
+libdeflate:
+- '1.14'
+openssl:
+- '3'
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.16openssl1.1.1.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.16openssl1.1.1.yaml
@@ -1,0 +1,29 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libcurl:
+- '7'
+libdeflate:
+- '1.16'
+openssl:
+- 1.1.1
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.16openssl3.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.16openssl3.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,12 +15,15 @@ docker_image:
 libcurl:
 - '7'
 libdeflate:
-- '1.14'
+- '1.16'
 openssl:
-- 1.1.1
+- '3'
 target_platform:
 - linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.17openssl1.1.1.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.17openssl1.1.1.yaml
@@ -1,26 +1,29 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '14'
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
 - '7'
 libdeflate:
-- '1.12'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '1.17'
+openssl:
+- 1.1.1
 target_platform:
-- osx-64
+- linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libcurl7libdeflate1.17openssl3.yaml
+++ b/.ci_support/linux_64_libcurl7libdeflate1.17openssl3.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,12 +15,15 @@ docker_image:
 libcurl:
 - '7'
 libdeflate:
-- '1.12'
+- '1.17'
 openssl:
 - '3'
 target_platform:
 - linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libcurl8libdeflate1.12openssl3.yaml
+++ b/.ci_support/linux_64_libcurl8libdeflate1.12openssl3.yaml
@@ -1,0 +1,29 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libcurl:
+- '8'
+libdeflate:
+- '1.12'
+openssl:
+- '3'
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libcurl8libdeflate1.13openssl3.yaml
+++ b/.ci_support/linux_64_libcurl8libdeflate1.13openssl3.yaml
@@ -1,0 +1,29 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libcurl:
+- '8'
+libdeflate:
+- '1.13'
+openssl:
+- '3'
+target_platform:
+- linux-64
+xz:
+- '5'
+zip_keys:
+- - openssl
+  - libcurl
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_libcurl8libdeflate1.14openssl3.yaml
+++ b/.ci_support/linux_64_libcurl8libdeflate1.14openssl3.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,14 +13,17 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.13'
+- '1.14'
 openssl:
 - '3'
 target_platform:
 - linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libcurl8libdeflate1.16openssl3.yaml
+++ b/.ci_support/linux_64_libcurl8libdeflate1.16openssl3.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,14 +13,17 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.17'
+- '1.16'
 openssl:
-- 1.1.1
+- '3'
 target_platform:
 - linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_libcurl8libdeflate1.17openssl3.yaml
+++ b/.ci_support/linux_64_libcurl8libdeflate1.17openssl3.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,14 +13,17 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.16'
+- '1.17'
 openssl:
-- 1.1.1
+- '3'
 target_platform:
 - linux-64
 xz:
 - '5'
+zip_keys:
+- - openssl
+  - libcurl
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_libcurl7libdeflate1.12.yaml
+++ b/.ci_support/osx_64_libcurl7libdeflate1.12.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,7 +15,7 @@ channel_targets:
 libcurl:
 - '7'
 libdeflate:
-- '1.17'
+- '1.12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_64_libcurl7libdeflate1.13.yaml
+++ b/.ci_support/osx_64_libcurl7libdeflate1.13.yaml
@@ -1,0 +1,26 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '7'
+libdeflate:
+- '1.13'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_libcurl7libdeflate1.14.yaml
+++ b/.ci_support/osx_64_libcurl7libdeflate1.14.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,7 +15,7 @@ channel_targets:
 libcurl:
 - '7'
 libdeflate:
-- '1.13'
+- '1.14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_64_libcurl7libdeflate1.16.yaml
+++ b/.ci_support/osx_64_libcurl7libdeflate1.16.yaml
@@ -1,11 +1,13 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,9 +17,9 @@ libcurl:
 libdeflate:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 target_platform:
-- osx-arm64
+- osx-64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_64_libcurl7libdeflate1.17.yaml
+++ b/.ci_support/osx_64_libcurl7libdeflate1.17.yaml
@@ -1,25 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
 - '7'
 libdeflate:
-- '1.13'
-openssl:
-- 1.1.1
+- '1.17'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 target_platform:
-- linux-64
+- osx-64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_64_libcurl8libdeflate1.12.yaml
+++ b/.ci_support/osx_64_libcurl8libdeflate1.12.yaml
@@ -1,25 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.17'
-openssl:
-- '3'
+- '1.12'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 target_platform:
-- linux-64
+- osx-64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_64_libcurl8libdeflate1.13.yaml
+++ b/.ci_support/osx_64_libcurl8libdeflate1.13.yaml
@@ -1,23 +1,25 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.14'
+- '1.13'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 target_platform:
-- osx-arm64
+- osx-64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_64_libcurl8libdeflate1.14.yaml
+++ b/.ci_support/osx_64_libcurl8libdeflate1.14.yaml
@@ -1,0 +1,26 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '8'
+libdeflate:
+- '1.14'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_libcurl8libdeflate1.16.yaml
+++ b/.ci_support/osx_64_libcurl8libdeflate1.16.yaml
@@ -7,13 +7,13 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
 libcurl:
-- '7'
+- '8'
 libdeflate:
 - '1.16'
 macos_machine:

--- a/.ci_support/osx_64_libcurl8libdeflate1.17.yaml
+++ b/.ci_support/osx_64_libcurl8libdeflate1.17.yaml
@@ -1,23 +1,25 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.14'
+MACOSX_SDK_VERSION:
+- '10.14'
 bzip2:
 - '1'
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.13'
+- '1.17'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 target_platform:
-- osx-arm64
+- osx-64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_arm64_libcurl7libdeflate1.12.yaml
+++ b/.ci_support/osx_arm64_libcurl7libdeflate1.12.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '7'
+libdeflate:
+- '1.12'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_libcurl7libdeflate1.13.yaml
+++ b/.ci_support/osx_arm64_libcurl7libdeflate1.13.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 libcurl:
 - '7'
 libdeflate:
-- '1.12'
+- '1.13'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/osx_arm64_libcurl7libdeflate1.14.yaml
+++ b/.ci_support/osx_arm64_libcurl7libdeflate1.14.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '7'
+libdeflate:
+- '1.14'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_libcurl7libdeflate1.16.yaml
+++ b/.ci_support/osx_arm64_libcurl7libdeflate1.16.yaml
@@ -1,25 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
 - '7'
 libdeflate:
 - '1.16'
-openssl:
-- '3'
+macos_machine:
+- arm64-apple-darwin20.0.0
 target_platform:
-- linux-64
+- osx-arm64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_arm64_libcurl7libdeflate1.17.yaml
+++ b/.ci_support/osx_arm64_libcurl7libdeflate1.17.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '7'
+libdeflate:
+- '1.17'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_libcurl8libdeflate1.12.yaml
+++ b/.ci_support/osx_arm64_libcurl8libdeflate1.12.yaml
@@ -1,25 +1,23 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.14'
-MACOSX_SDK_VERSION:
-- '10.14'
+- '11.0'
 bzip2:
 - '1'
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.14'
+- '1.12'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 target_platform:
-- osx-64
+- osx-arm64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_arm64_libcurl8libdeflate1.13.yaml
+++ b/.ci_support/osx_arm64_libcurl8libdeflate1.13.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '8'
+libdeflate:
+- '1.13'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_libcurl8libdeflate1.14.yaml
+++ b/.ci_support/osx_arm64_libcurl8libdeflate1.14.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '8'
+libdeflate:
+- '1.14'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_libcurl8libdeflate1.16.yaml
+++ b/.ci_support/osx_arm64_libcurl8libdeflate1.16.yaml
@@ -1,25 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_name:
-- cos6
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - tiledb main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
 libcurl:
-- '7'
+- '8'
 libdeflate:
-- '1.12'
-openssl:
-- 1.1.1
+- '1.16'
+macos_machine:
+- arm64-apple-darwin20.0.0
 target_platform:
-- linux-64
+- osx-arm64
 xz:
 - '5'
 zlib:

--- a/.ci_support/osx_arm64_libcurl8libdeflate1.17.yaml
+++ b/.ci_support/osx_arm64_libcurl8libdeflate1.17.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- tiledb main
+libcurl:
+- '8'
+libdeflate:
+- '1.17'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+xz:
+- '5'
+zlib:
+- '1.2'

--- a/README.md
+++ b/README.md
@@ -29,143 +29,248 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_libdeflate1.12openssl1.1.1</td>
+              <td>linux_64_libcurl7libdeflate1.12openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.12openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.12openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.12openssl3</td>
+              <td>linux_64_libcurl7libdeflate1.12openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.12openssl3" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.12openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.13openssl1.1.1</td>
+              <td>linux_64_libcurl7libdeflate1.13openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.13openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.13openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.13openssl3</td>
+              <td>linux_64_libcurl7libdeflate1.13openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.13openssl3" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.13openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.14openssl1.1.1</td>
+              <td>linux_64_libcurl7libdeflate1.14openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.14openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.14openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.14openssl3</td>
+              <td>linux_64_libcurl7libdeflate1.14openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.14openssl3" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.14openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.16openssl1.1.1</td>
+              <td>linux_64_libcurl7libdeflate1.16openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.16openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.16openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.16openssl3</td>
+              <td>linux_64_libcurl7libdeflate1.16openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.16openssl3" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.16openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.17openssl1.1.1</td>
+              <td>linux_64_libcurl7libdeflate1.17openssl1.1.1</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.17openssl1.1.1" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.17openssl1.1.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libdeflate1.17openssl3</td>
+              <td>linux_64_libcurl7libdeflate1.17openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libdeflate1.17openssl3" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl7libdeflate1.17openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_libdeflate1.12</td>
+              <td>linux_64_libcurl8libdeflate1.12openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libdeflate1.12" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl8libdeflate1.12openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_libdeflate1.13</td>
+              <td>linux_64_libcurl8libdeflate1.13openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libdeflate1.13" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl8libdeflate1.13openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_libdeflate1.14</td>
+              <td>linux_64_libcurl8libdeflate1.14openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libdeflate1.14" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl8libdeflate1.14openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_libdeflate1.16</td>
+              <td>linux_64_libcurl8libdeflate1.16openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libdeflate1.16" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl8libdeflate1.16openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_libdeflate1.17</td>
+              <td>linux_64_libcurl8libdeflate1.17openssl3</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libdeflate1.17" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libcurl8libdeflate1.17openssl3" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_libdeflate1.12</td>
+              <td>osx_64_libcurl7libdeflate1.12</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libdeflate1.12" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl7libdeflate1.12" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_libdeflate1.13</td>
+              <td>osx_64_libcurl7libdeflate1.13</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libdeflate1.13" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl7libdeflate1.13" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_libdeflate1.14</td>
+              <td>osx_64_libcurl7libdeflate1.14</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libdeflate1.14" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl7libdeflate1.14" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_libdeflate1.16</td>
+              <td>osx_64_libcurl7libdeflate1.16</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libdeflate1.16" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl7libdeflate1.16" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_libdeflate1.17</td>
+              <td>osx_64_libcurl7libdeflate1.17</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libdeflate1.17" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl7libdeflate1.17" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libcurl8libdeflate1.12</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl8libdeflate1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libcurl8libdeflate1.13</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl8libdeflate1.13" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libcurl8libdeflate1.14</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl8libdeflate1.14" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libcurl8libdeflate1.16</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl8libdeflate1.16" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_libcurl8libdeflate1.17</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libcurl8libdeflate1.17" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl7libdeflate1.12</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl7libdeflate1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl7libdeflate1.13</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl7libdeflate1.13" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl7libdeflate1.14</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl7libdeflate1.14" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl7libdeflate1.16</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl7libdeflate1.16" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl7libdeflate1.17</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl7libdeflate1.17" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl8libdeflate1.12</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl8libdeflate1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl8libdeflate1.13</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl8libdeflate1.13" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl8libdeflate1.14</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl8libdeflate1.14" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl8libdeflate1.16</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl8libdeflate1.16" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_libcurl8libdeflate1.17</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/feedstock-builds/_build/latest?definitionId=&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/feedstock-builds/_apis/build/status/htslib-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_libcurl8libdeflate1.17" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -15,3 +15,11 @@ libdeflate:
 openssl:
   - 1.1.1
   - 3
+  - 3
+libcurl:
+  - 7
+  - 7
+  - 8
+zip_keys:
+  - openssl
+  - libcurl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
   run_exports:
     - {{ pin_subpackage('htslib', max_pin='x.x') }}
 


### PR DESCRIPTION
Add curl-7/8 + openssl 1.1.1/3 build variants. This should fix the macos amr64 build failures for TileDB-VCF feedstock see in https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/84