### PR TITLE
[ci skip] Only upload conda binaries from main branch

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -86,6 +86,7 @@ jobs:
         export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export UPLOAD_ON_BRANCH="main"
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
           export IS_PR_BUILD="True"
         else

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -80,6 +80,7 @@ jobs:
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export UPLOAD_ON_BRANCH="main"
       if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
         export IS_PR_BUILD="True"
       else

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -14,3 +14,4 @@ azure:
   build_id: 44
   user_or_org: TileDB-Inc
   project_name: CI
+upload_on_branch: main


### PR DESCRIPTION
To prevent prematurely uploading conda binaries from internal feature branches