### PR TITLE
Bump to 1.19 and remove redundant runtime requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,23 @@
-{% set version = "1.16" %}
+{% set version = "1.19" %}
 
 package:
   name: htslib
   version: {{ version }}
 
 build:
-  number: 6
+  number: 0
   run_exports:
     - {{ pin_subpackage('htslib', max_pin='x.x') }}
 
 source:
   url: https://github.com/samtools/htslib/releases/download/{{ version }}/htslib-{{ version }}.tar.bz2
-  sha256: 606b7c7aff73734cf033ecd156f40529fa5792f54524952a28938ca0890d7924
+  sha256: 8751c40c4fa7d1f23a6864c5b20a73744f8be68239535ae7729c5f7d394d0736
 
 requirements:
   build:
     - make
     - {{ compiler('c') }}
   host:
-    - libcurl
-    - bzip2
-    - xz
-    - zlib
-    - libdeflate
-    - openssl  # [not osx]
-  run:
     - libcurl
     - bzip2
     - xz


### PR DESCRIPTION
Modeled after current bioconda recipe

https://github.com/bioconda/bioconda-recipes/blob/c3eefe66f8c912f9f565b65467178c0f5b426e7e/recipes/htslib/meta.yaml

xref: https://github.com/TileDB-Inc/tiledb-vcf-feedstock/issues/106